### PR TITLE
The up/down buttons are offset in height in ie 8.

### DIFF
--- a/ui.spinner.css
+++ b/ui.spinner.css
@@ -1,3 +1,3 @@
-.ui-spinner {position: relative}
+.ui-spinner {position: relative; border: 0px solid white; }
 .ui-spinner-buttons {position: absolute}
 .ui-spinner-button {overflow: hidden}


### PR DESCRIPTION
Applied wensting's fix from Issue #4. So far it seems to have fixed the button offset problem when tested in IE8. I also tested it successfully in IE7 (compability mode), Firefox 3, and Chrome 12.
