### PR TITLE
This fixed the mouse wheel for the latest version of jquery.js

### DIFF
--- a/ui.spinner.js
+++ b/ui.spinner.js
@@ -452,6 +452,12 @@ $.widget('ui.spinner', {
 	},
 		
 	_mouseWheel: function(e) {
+		// The wheel data is not added to the jquery event as for jquery 1.7
+		// see http://bugs.jquery.com/ticket/10676
+		if( typeof e.wheelDelta=="undefined" && typeof e.detail=="undefined" ) {
+			e = e.originalEvent;
+		}
+
 		var self = $.data(this, 'spinner');
 		if (!self.options.disabled && self.focused && (focusCtrl === self)) {
 			// make sure changes are posted


### PR DESCRIPTION
It was not working when using this widget with the latest version of jquery.js (1.7.2)
The wheel information "wheelDelta" or "detail"  is not included on the jquery event as for jquery 1.7 
see http://bugs.jquery.com/ticket/10676
